### PR TITLE
Revert "changing to stable version for python orb"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   shellcheck: circleci/shellcheck@volatile
-  python: circleci/python@1.1.0
+  python: circleci/python@volatile
   # eventually
   # bats: circleci/bats@volatile
   # codecov: codecov/codecov@volatile


### PR DESCRIPTION
Reverts elreydetoda/packer-kali_linux#63

apparently this wasn't the issue, check out #62 for more details