### PR TITLE
Fix/kali base install/85

### DIFF
--- a/scripts/new-kali.sh
+++ b/scripts/new-kali.sh
@@ -98,6 +98,12 @@ function cryptographical_verification() {
 
   # showing the hash signature url
   printf '\ncurrent url for hash algorithm for the %s version is:\n%s\n\n' "${kaliInstallVersion}" "${kaliCurrentHashUrl}"
+  # show mirror where retrieved from
+  #   showing possible mirrors
+  
+  printf '\npotential mirrors for hash algorithm %s\nselected mirror%s\n\n' \
+    "$(curl -I "${kaliCurrentHashUrl}")" \
+    "$(curl -sw '%{redirect_url}' -o /dev/null "${kaliCurrentHashUrl}")"
 
   echo "Starting ISO signature validation process."
   # downloading the hash algorithm file contents

--- a/scripts/new-kali.sh
+++ b/scripts/new-kali.sh
@@ -205,7 +205,7 @@ function main() {
   # this is the version in the web path for the folder that has the kali ISOs in it
   #   i.e. https://cdimage.kali.org/kali-weekly/ or https://cdimage.kali.org/kali-2020.3/
   # TODO: perscribed by offsec patch for #85 in github
-  KALIVERSION="kali-weekly"
+  # KALIVERSION="kali-weekly"
   kaliInstallVersion="${KALIVERSION:-current}"
   # this is the iso version you would like to install
   #   i.e. installer-amd64.iso or netinst-amd64.iso

--- a/scripts/new-kali.sh
+++ b/scripts/new-kali.sh
@@ -100,7 +100,6 @@ function cryptographical_verification() {
   printf '\ncurrent url for hash algorithm for the %s version is:\n%s\n\n' "${kaliInstallVersion}" "${kaliCurrentHashUrl}"
   # show mirror where retrieved from
   #   showing possible mirrors
-  
   printf '\npotential mirrors for hash algorithm %s\nselected mirror%s\n\n' \
     "$(curl -I "${kaliCurrentHashUrl}")" \
     "$(curl -sw '%{redirect_url}' -o /dev/null "${kaliCurrentHashUrl}")"
@@ -141,7 +140,7 @@ function info_enum() {
   printf '\nthe current hash alg chosen: %s\n' "${hashAlgOut}"
   # packer_var_json_string+="$(printf '"iso_checksum_type":"%s",' "${hashAlgOut}")"
 
-  if ! grep "${currentKaliISO}" "${tmpDir}/${hashAlg}" &> /dev/null ; then
+  if ! grep "${currentKaliISO}" "${tmpDir}/${hashAlg}" &> /dev/null; then
     cat "${tmpDir}/${hashAlg}"
     exit 1
   fi

--- a/scripts/new-kali.sh
+++ b/scripts/new-kali.sh
@@ -100,7 +100,7 @@ function cryptographical_verification() {
   printf '\ncurrent url for hash algorithm for the %s version is:\n%s\n\n' "${kaliInstallVersion}" "${kaliCurrentHashUrl}"
   # show mirror where retrieved from
   #   showing possible mirrors
-  printf '\npotential mirrors for hash algorithm %s\nselected mirror%s\n\n' \
+  printf '\npotential mirrors for hash algorithm:\n%s\n\nselected mirror: %s\n\n' \
     "$(curl -I "${kaliCurrentHashUrl}")" \
     "$(curl -sw '%{redirect_url}' -o /dev/null "${kaliCurrentHashUrl}")"
 

--- a/scripts/new-kali.sh
+++ b/scripts/new-kali.sh
@@ -194,6 +194,8 @@ function main() {
   kaliBaseUrl='https://cdimage.kali.org'
   # this is the version in the web path for the folder that has the kali ISOs in it
   #   i.e. https://cdimage.kali.org/kali-weekly/ or https://cdimage.kali.org/kali-2020.3/
+  # TODO: perscribed by offsec patch for #85 in github
+  KALIVERSION="kali-weekly"
   kaliInstallVersion="${KALIVERSION:-current}"
   # this is the iso version you would like to install
   #   i.e. installer-amd64.iso or netinst-amd64.iso

--- a/scripts/new-kali.sh
+++ b/scripts/new-kali.sh
@@ -135,6 +135,11 @@ function info_enum() {
   printf '\nthe current hash alg chosen: %s\n' "${hashAlgOut}"
   # packer_var_json_string+="$(printf '"iso_checksum_type":"%s",' "${hashAlgOut}")"
 
+  if ! grep "${currentKaliISO}" "${tmpDir}/${hashAlg}" &> /dev/null ; then
+    cat "${tmpDir}/${hashAlg}"
+    exit 1
+  fi
+
   currentHashSum=$(grep "${currentKaliISO}" "${tmpDir}/${hashAlg}" | cut -d ' ' -f 1)
   printf '\nthe current hash for that file is: %s\n' "${currentHashSum}"
   packer_var_json_string+="$(printf '"iso_checksum":"%s",' "${currentHashSum}")"


### PR DESCRIPTION
added some extra debugging steps, but I think I will be able to ignore the issue because they are now releasing 2020.4