### PR TITLE
updating terraform provider & helper script

### DIFF
--- a/ci/packet_terraform-cloud/.terraform.lock.hcl
+++ b/ci/packet_terraform-cloud/.terraform.lock.hcl
@@ -1,0 +1,38 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/equinix/metal" {
+  version = "1.1.0"
+  hashes = [
+    "h1:0BNQ6KPD4KHl3W0JvI8B/fx+FHcw0uPdtV2tHVcMg84=",
+    "zh:3fa3f8d7d7098a70c02f866ea45c718a0a2bec611730595c41b94251eed6f445",
+    "zh:400c107fa0e9a5e31a7e330295a2e48e70503fd908296aba33d1008ddb7840bd",
+    "zh:4998994a71aeb88a3d5e909c30e3aa70a56a26a6764d266a1493958352157e73",
+    "zh:582d0e81455f12759e8e9ca17ce75323b51c661d187367cfed21e9f4277c86a0",
+    "zh:68bab42ebdefb86da5374e16897be743ccbd4cdd5968cf0c1cf0a16791a99a5e",
+    "zh:7a61c7cf256b47621b4407d16cce964a50c7b75674952fb812d2e2cb04fdda6e",
+    "zh:95feee424de8de1f1612e633267bfbcfc0dedc82d841eb8abd0b0cc671418a05",
+    "zh:a9e2f1596f472693a66cc1b3571e8a1325de233c78e6a548d1adacd5b7c934b8",
+    "zh:b420f328e78a645a5d362b078a07ff0223b9bc285a301fed5a9e36b625ef0aae",
+    "zh:f6edceb76ca69359cce2064f70dcf08144de998e559eaceba8dfd0846a761e43",
+    "zh:fd2746ea1a4a192a9ea8d91eef92351d7feffba982b2645d0c9a9eb5a2cd97ba",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/http" {
+  version = "2.1.0"
+  hashes = [
+    "h1:HmUcHqc59VeHReHD2SEhnLVQPUKHKTipJ8Jxq67GiDU=",
+    "zh:03d82dc0887d755b8406697b1d27506bc9f86f93b3e9b4d26e0679d96b802826",
+    "zh:0704d02926393ddc0cfad0b87c3d51eafeeae5f9e27cc71e193c141079244a22",
+    "zh:095ea350ea94973e043dad2394f10bca4a4bf41be775ba59d19961d39141d150",
+    "zh:0b71ac44e87d6964ace82979fc3cbb09eb876ed8f954449481bcaa969ba29cb7",
+    "zh:0e255a170db598bd1142c396cefc59712ad6d4e1b0e08a840356a371e7b73bc4",
+    "zh:67c8091cfad226218c472c04881edf236db8f2dc149dc5ada878a1cd3c1de171",
+    "zh:75df05e25d14b5101d4bc6624ac4a01bb17af0263c9e8a740e739f8938b86ee3",
+    "zh:b4e36b2c4f33fdc44bf55fa1c9bb6864b5b77822f444bd56f0be7e9476674d0e",
+    "zh:b9b36b01d2ec4771838743517bc5f24ea27976634987c6d5529ac4223e44365d",
+    "zh:ca264a916e42e221fddb98d640148b12e42116046454b39ede99a77fc52f59f4",
+    "zh:fe373b2fb2cc94777a91ecd7ac5372e699748c455f44f6ea27e494de9e5e6f92",
+  ]
+}

--- a/ci/packet_terraform-cloud/main.tf
+++ b/ci/packet_terraform-cloud/main.tf
@@ -55,7 +55,7 @@ variable "provision_plan" {
 ##################################################
 ##  Packet server provisioning
 # defining the packet provider
-provider "packet" {
+provider "metal" {
   auth_token = var.packet_auth_token
 }
 
@@ -66,17 +66,17 @@ data "http" "current_ip" {
 }
 
 # querying for LTS based on server OS and type
-data "packet_operating_system" "ubuntu_lts" {
+data "metal_operating_system" "ubuntu_lts" {
   distro           = "ubuntu"
   version          = "20.04"
   provisionable_on = var.provision_plan
 }
 
 # provisioning the actual server based on above info
-resource "packet_device" "packer_build_server" {
+resource "metal_device" "packer_build_server" {
   hostname         = var.server_hostname
   project_id       = var.project_id
-  operating_system = data.packet_operating_system.ubuntu_lts.id
+  operating_system = data.metal_operating_system.ubuntu_lts.id
   plan             = var.provision_plan
   facilities       = ["any"]
   # TODO: remove
@@ -90,7 +90,7 @@ resource "packet_device" "packer_build_server" {
 # outputing server ip address, so scripts are able
 #   to reference it
 output "server_ip" {
-  value = packet_device.packer_build_server.access_public_ipv4
+  value = metal_device.packer_build_server.access_public_ipv4
 }
 
 # outputing your ip address, so scripts are able
@@ -105,8 +105,8 @@ terraform {
     http = {
       source = "hashicorp/http"
     }
-    packet = {
-      source = "terraform-providers/packet"
+    metal = {
+      source = "equinix/metal"
     }
   }
   required_version = ">= 0.13"

--- a/scripts/terraform-helper.sh
+++ b/scripts/terraform-helper.sh
@@ -56,7 +56,7 @@ function terraform_stuff() {
       ;;
     *)
       IFS=" " read -r -a extra_args <<< "${@:2}"
-      if [[ -z "${extra_args[*]}" ]] ; then
+      if [[ -z "${extra_args[*]}" ]]; then
         extra_args=()
       fi
       ;;

--- a/scripts/terraform-helper.sh
+++ b/scripts/terraform-helper.sh
@@ -55,7 +55,10 @@ function terraform_stuff() {
       fi
       ;;
     *)
-      extra_args=()
+      IFS=" " read -r -a extra_args <<< "${@:2}"
+      if [[ -z "${extra_args[*]}" ]] ; then
+        extra_args=()
+      fi
       ;;
 
   esac


### PR DESCRIPTION
updated terraform provider to use new equinix metal terraform provider ( saw packethost/packet migrated from [here](https://github.com/packethost/terraform-provider-packet/issues/303) ).

updated provider, because I had a [strange error](https://app.circleci.com/pipelines/github/elreydetoda/packer-kali_linux/379/workflows/f8bbe444-3a6d-46b1-88ce-0ee8133326f1) and just wanted to check.