### PR TITLE
adding qemu/libvirt support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -320,7 +320,11 @@ jobs:
           pipenv run python --version
       - run-black_linter
 
-  packer-linting_vbox:
+  packer-linting:
+    parameters:
+      hypervisor:
+        description: hypervisor to validate
+        type: string
     docker:
       - image: 'hashicorp/packer:light'
     steps:
@@ -333,37 +337,8 @@ jobs:
       - packer-lint:
           template-file: kali-template.json
           vars-file: variables.json
-          only-builder: virtualbox-iso
+          only-builder: '<< parameters.hypervisor >>'
 
-  packer-linting_vmware:
-    docker:
-      - image: 'hashicorp/packer:light'
-    steps:
-      - attach_workspace:
-          at: /tmp/packer_workspace
-      - checkout
-      - submodule-sync
-      - run: cp -v /tmp/packer_workspace/* .
-      - run: packer version
-      - packer-lint:
-          template-file: kali-template.json
-          vars-file: variables.json
-          only-builder: vmware-iso
-
-  packer-linting_aws:
-    docker:
-      - image: 'hashicorp/packer:light'
-    steps:
-      - attach_workspace:
-          at: /tmp/packer_workspace
-      - checkout
-      - submodule-sync
-      - run: cp -v /tmp/packer_workspace/* .
-      - run: packer version
-      - packer-lint:
-          template-file: templates/template.json
-          vars-file: templates/example-variables.json
-          only-builder: amazon-ebs
 
   terraform-linting:
     # executor: terraform/default
@@ -373,7 +348,7 @@ jobs:
       - run: terraform --version
       # linting the packet terraform files
       - terraform-lint:
-          code-path: ci/packet_terraform-cloud
+          code-path: ci/packet_terraform-cloud-build_all
       # linting the aws terraform files
       # - terraform-lint:
       #     code-path: ci/kali_aws_info
@@ -493,7 +468,7 @@ jobs:
     steps:
       - run: terraform --version
       - terraform-deploy:
-          code-path: ci/packet_terraform-cloud
+          code-path: ci/packet_terraform-cloud-build_all
 
 
   terraform-packet_destroy:
@@ -502,7 +477,7 @@ jobs:
     steps:
       - run: terraform --version
       - terraform-destroy:
-          code-path: ci/packet_terraform-cloud
+          code-path: ci/packet_terraform-cloud-build_all
 
   ansible-bootstrap:
     docker:
@@ -520,6 +495,10 @@ jobs:
   ansible-packer_build:
     docker:
       - image: 'elrey741/ansible-playbook_packet:alpine'
+    parameters:
+      build:
+        description: build target for packer to hit
+        type: string
     steps:
       - ansible-prep
       - add_ssh_keys:
@@ -538,7 +517,7 @@ jobs:
           command: |
             ansible-playbook -i ci/scripts/packet_net.py -u root \
               -e "api_key_from_env=${TEXTBELT_KEY:-} phone_from_env=${PERSONAL_NUM:-}" \
-              -e CIRCLECI="${CIRCLECI:-}" ci/packer_build.yml
+              -e CIRCLECI="${CIRCLECI:-}" ci/packer_build.yml --limit="packer-build-box-<< parameters.build >>"
       - run: |
           mkdir -p /tmp/artifacts
           pwd && ls
@@ -567,18 +546,10 @@ workflows:
       - ansible-linting
       - generate-packer-file
       - generate-packer-vars
-      - packer-linting_vbox:
-          requires:
-            - generate-packer-vars
-            - generate-packer-file
-            - shellcheck-warning
-            - shfmt-linting
-            - terraform-linting
-            - markdown-linting
-            - gh_issues-linting
-            - python-linting
-            - ansible-linting
-      - packer-linting_vmware:
+      - packer-linting:
+          matrix:
+            parameters:
+              hypervisor: [ "virtualbox-iso", "vmware-iso", "qemu" ]
           requires:
             - generate-packer-vars
             - generate-packer-file
@@ -591,12 +562,14 @@ workflows:
             - ansible-linting
       - terraform-packet_deploy:
           requires:
-            - packer-linting_vbox
-            - packer-linting_vmware
+            - packer-linting
       - ansible-bootstrap:
           requires:
             - terraform-packet_deploy
       - ansible-packer_build:
+          matrix:
+            parameters:
+              build: [ "v", "qemu" ]
           requires:
             - ansible-bootstrap
       - terraform-packet_destroy:
@@ -659,11 +632,10 @@ workflows:
               ignore:
                 - master
                 - dev-stage
-      - packer-linting_vbox:
-          requires:
-            - generate-packer-vars
-            - generate-packer-file
-      - packer-linting_vmware:
+      - packer-linting:
+          matrix:
+            parameters:
+              hypervisor: [ "virtualbox-iso", "vmware-iso", "qemu" ]
           requires:
             - generate-packer-vars
             - generate-packer-file
@@ -715,18 +687,10 @@ workflows:
             branches:
               only:
                 - master
-      - packer-linting_vbox:
-          requires:
-            - generate-packer-vars
-            - generate-packer-file
-            - shellcheck-warning
-            - shfmt-linting
-            - terraform-linting
-            - markdown-linting
-            - gh_issues-linting
-            - python-linting
-            - ansible-linting
-      - packer-linting_vmware:
+      - packer-linting:
+          matrix:
+            parameters:
+              hypervisor: [ "virtualbox-iso", "vmware-iso", "qemu" ]
           requires:
             - generate-packer-vars
             - generate-packer-file
@@ -739,12 +703,14 @@ workflows:
             - ansible-linting
       - terraform-packet_deploy:
           requires:
-            - packer-linting_vbox
-            - packer-linting_vmware
+            - packer-linting
       - ansible-bootstrap:
           requires:
             - terraform-packet_deploy
       - ansible-packer_build:
+          matrix:
+            parameters:
+              build: [ "v", "qemu" ]
           requires:
             - ansible-bootstrap
       - terraform-packet_destroy:
@@ -801,18 +767,10 @@ workflows:
             branches:
               only:
                 - dev-stage
-      - packer-linting_vbox:
-          requires:
-            - generate-packer-vars
-            - generate-packer-file
-            - shellcheck-warning
-            - shfmt-linting
-            - terraform-linting
-            - markdown-linting
-            - gh_issues-linting
-            - python-linting
-            - ansible-linting
-      - packer-linting_vmware:
+      - packer-linting:
+          matrix:
+            parameters:
+              hypervisor: [ "virtualbox-iso", "vmware-iso", "qemu" ]
           requires:
             - generate-packer-vars
             - generate-packer-file
@@ -825,12 +783,14 @@ workflows:
             - ansible-linting
       - terraform-packet_deploy:
           requires:
-            - packer-linting_vbox
-            - packer-linting_vmware
+            - packer-linting
       - ansible-bootstrap:
           requires:
             - terraform-packet_deploy
       - ansible-packer_build:
+          matrix:
+            parameters:
+              build: [ "v", "qemu" ]
           requires:
             - ansible-bootstrap
       - terraform-packet_destroy:

--- a/ci/bootstrap.yml
+++ b/ci/bootstrap.yml
@@ -64,6 +64,16 @@
             interface: 'vmnet8'
             comment: 'for vmware builder'
 
+        - name: adding vmware access through ufw
+          ufw:
+            # rule: limit
+            # setting it to this for now
+            rule: allow
+            proto: any
+            direction: 'in'
+            interface: 'virbr0'
+            comment: 'for libvirt builder'
+
         - name: enabling ufw
           ufw:
             state: enabled

--- a/ci/packer_build.yml
+++ b/ci/packer_build.yml
@@ -41,14 +41,22 @@
         - name: initial upload to vagrant cloud
           block:
 
+            - name: setting provider string for vbox & vmware
+              set_fact:
+                provider_string: 'virtualbox-iso|vmware-iso'
+              when: ansible_hostname == 'packer-build-box-v'
+
+            - name: setting provider string for qemu
+              set_fact:
+                provider_string: 'qemu'
+              when: ansible_hostname == 'packer-build-box-qemu'
+
             - name: launching the packer build process
               script:
                 cmd: "{{ local_ci_scripts_dir }}/packer_build-wrapper.sh '{{ provider_string }}'"
                 chdir: '{{ kali_project_folder }}'
               args:
                 creates: '{{ kali_project_folder }}/packer_build.log'
-              vars:
-                provider_string: 'virtualbox-iso|vmware-iso'
 
             - name: sending last text message for end
               import_role:

--- a/ci/packer_build.yml
+++ b/ci/packer_build.yml
@@ -34,7 +34,7 @@
           vars:
             api_key: '{{ api_key_from_env }}'
             phone_number: '{{ phone_from_env }}'
-            message_contents: 'starting build'
+            message_contents: 'starting build: {{ ansible_hostname }}'
           when: (( api_key_from_env is defined ) and ( api_key_from_env | length > 0 )) and
                 ((phone_from_env is defined ) and ( phone_from_env | length > 0 ))
 
@@ -64,7 +64,7 @@
               vars:
                 api_key: '{{ api_key_from_env }}'
                 phone_number: '{{ phone_from_env }}'
-                message_contents: 'finished successfuly, and ending build'
+                message_contents: 'finished successfuly, and ending build: {{ ansible_hostname }}'
               when: (( api_key_from_env is defined ) and ( api_key_from_env | length > 0 )) and
                     ((phone_from_env is defined ) and ( phone_from_env | length > 0 ))
 
@@ -76,7 +76,7 @@
               vars:
                 api_key: '{{ api_key_from_env }}'
                 phone_number: '{{ phone_from_env }}'
-                message_contents: 'build failed (probably upload), but trying to upload with curl script'
+                message_contents: 'build failed (probably upload), but trying to upload with curl script: {{ ansible_hostname }}'
               when: (( api_key_from_env is defined ) and ( api_key_from_env | length > 0 )) and
                     ((phone_from_env is defined ) and ( phone_from_env | length > 0 ))
 
@@ -103,7 +103,7 @@
               vars:
                 api_key: '{{ api_key_from_env }}'
                 phone_number: '{{ phone_from_env }}'
-                message_contents: 'finished successfuly, and ending build'
+                message_contents: 'finished successfuly, and ending build: {{ ansible_hostname }}'
               when: (( api_key_from_env is defined ) and ( api_key_from_env | length > 0 )) and
                     ((phone_from_env is defined ) and ( phone_from_env | length > 0 ))
 
@@ -115,7 +115,7 @@
           vars:
             api_key: '{{ api_key_from_env }}'
             phone_number: '{{ phone_from_env }}'
-            message_contents: "didn't complete properly, and ending build"
+            message_contents: "didn't complete properly, and ending build: {{ ansible_hostname }}"
           when: (( api_key_from_env is defined ) and ( api_key_from_env | length > 0 )) and
                 ((phone_from_env is defined ) and ( phone_from_env | length > 0 ))
 

--- a/ci/packet_terraform-cloud-build_all/.terraform.lock.hcl
+++ b/ci/packet_terraform-cloud-build_all/.terraform.lock.hcl
@@ -1,0 +1,40 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/equinix/metal" {
+  version = "2.0.1"
+  hashes = [
+    "h1:ZFZT9ixEw+nNH0c5Fwz9Rb0+yfpGKEUIZ13jKI7hOzM=",
+    "zh:055d27d0b5a5eee7f48d948b2e2ea8204954fa4e45ffd203bab8593fb66291aa",
+    "zh:073ba05ca30ec92ac2eacb1b8539b154380999a15fffed0944d757e0f0a7e27b",
+    "zh:2be9be63f0b1dc6f7701fab349d23ac85dac0140e3618223f856fc875a7612a5",
+    "zh:2da94f3a92c859d88dc417f2301a4a343f74c24596e05a47fcfd7d7b31ac9786",
+    "zh:2dc856db0829147480922a0584c3f72894cd015699cb7b712ace02a18c19b0f5",
+    "zh:6452e22cdb13f8150f8b22c973776ec69489a5b17b2a1b30cea20c00387393bc",
+    "zh:653186e06a141f8ecc4584ad45524e05dd6b8f2baf4893bae36d7d231359696c",
+    "zh:7835807eacfc8d1f4a81d9c9cf8d3db4f5a04770c8f5ee9fc670d0e7a352cc32",
+    "zh:a50282178e96f8c9aa36d7f9d625b30804991029b8900b69d999606b1403a9b3",
+    "zh:b02691dcb6d488b16976a27cb80b6cbefabd58aab2cb54cb0267aaf1c663b8b3",
+    "zh:c47df9ff3a6f4312f9d6695c3635a2bd849f548de5a2805b056a1d316f0bef5f",
+    "zh:d589808da4d9311918580f1ca0029fb2dd166b05b19e927ba03520cef9bc4f80",
+    "zh:df16e461d7f52b18ecd403c45107f090e792b6a5e3b0a68e3c7876d37fd6d931",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/http" {
+  version = "2.1.0"
+  hashes = [
+    "h1:HmUcHqc59VeHReHD2SEhnLVQPUKHKTipJ8Jxq67GiDU=",
+    "zh:03d82dc0887d755b8406697b1d27506bc9f86f93b3e9b4d26e0679d96b802826",
+    "zh:0704d02926393ddc0cfad0b87c3d51eafeeae5f9e27cc71e193c141079244a22",
+    "zh:095ea350ea94973e043dad2394f10bca4a4bf41be775ba59d19961d39141d150",
+    "zh:0b71ac44e87d6964ace82979fc3cbb09eb876ed8f954449481bcaa969ba29cb7",
+    "zh:0e255a170db598bd1142c396cefc59712ad6d4e1b0e08a840356a371e7b73bc4",
+    "zh:67c8091cfad226218c472c04881edf236db8f2dc149dc5ada878a1cd3c1de171",
+    "zh:75df05e25d14b5101d4bc6624ac4a01bb17af0263c9e8a740e739f8938b86ee3",
+    "zh:b4e36b2c4f33fdc44bf55fa1c9bb6864b5b77822f444bd56f0be7e9476674d0e",
+    "zh:b9b36b01d2ec4771838743517bc5f24ea27976634987c6d5529ac4223e44365d",
+    "zh:ca264a916e42e221fddb98d640148b12e42116046454b39ede99a77fc52f59f4",
+    "zh:fe373b2fb2cc94777a91ecd7ac5372e699748c455f44f6ea27e494de9e5e6f92",
+  ]
+}

--- a/ci/packet_terraform-cloud-build_all/main.tf
+++ b/ci/packet_terraform-cloud-build_all/main.tf
@@ -1,0 +1,142 @@
+##################################################
+## NOTE
+# if you are a person that does IaC (Infrastructure as Code)
+#   for a living then please don't be mad at me for not following
+#   convention of breaking out this file into multiple files
+#   (i.e. variables.tf and output.tf) it is easier to showcase
+#   at conferences and it does very little, so that is why I have
+#   it all in one "big" file.
+
+##################################################
+## backend is where your state file lives
+terraform {
+  backend "remote" {
+    organization = "personal_projects_e"
+
+    workspaces {
+      name = "packer-kali_linux"
+    }
+  }
+}
+
+##################################################
+## Variables that are getting inputted (i.e. variables.tf)
+#   set the PACKET_AUTH_TOKEN env variable for auth
+#   or the auth_token is required
+variable "packet_auth_token" {
+  description = "The auth token for the account"
+  type        = string
+}
+
+variable "project_id" {
+  description = "The ID of the project the device (server) belongs to."
+  type        = string
+}
+
+##################################################
+# variables that start with v = virtualbox/vmware
+# variables that start with q = qemu
+
+variable "v_server_hostname" {
+  description = "The hostname of the device (server) getting assigned."
+  type        = string
+  default     = "packer-build-box-v"
+}
+
+variable "q_server_hostname" {
+  description = "The hostname of the device (server) getting assigned."
+  type        = string
+  default     = "packer-build-box-qemu"
+}
+
+# NOTE: this needs to be a baremetal host
+#   or else packer won't work
+#   https://www.packet.com/developers/os-compatibility/
+#   https://www.packet.com/developers/api/operatingsystems/
+variable "provision_plan" {
+  description = "The type of the device (server) getting assigned."
+  type        = string
+  default     = "c3.small.x86"
+}
+
+##################################################
+##  Packet server provisioning
+# defining the packet provider
+provider "metal" {
+  auth_token = var.packet_auth_token
+}
+
+# querying current ip address, so it is able to only whitelist
+#   this ip address for incoming connections
+data "http" "current_ip" {
+  url = "https://api.ipify.org/?format=json"
+}
+
+# querying for LTS based on server OS and type
+data "metal_operating_system" "v_ubuntu_lts" {
+  distro           = "ubuntu"
+  version          = "20.04"
+  provisionable_on = var.provision_plan
+}
+
+data "metal_operating_system" "q_ubuntu_lts" {
+  distro           = "ubuntu"
+  version          = "20.04"
+  provisionable_on = var.provision_plan
+}
+
+# provisioning the actual server based on above info
+resource "metal_device" "v_packer_build_server" {
+  hostname         = var.v_server_hostname
+  project_id       = var.project_id
+  operating_system = data.metal_operating_system.v_ubuntu_lts.id
+  plan             = var.provision_plan
+  facilities       = ["any"]
+  billing_cycle    = "hourly"
+  tags = [
+    "virtualbox-iso", "vmware"
+  ]
+
+}
+resource "metal_device" "q_packer_build_server" {
+  hostname         = var.q_server_hostname
+  project_id       = var.project_id
+  operating_system = data.metal_operating_system.q_ubuntu_lts.id
+  plan             = var.provision_plan
+  facilities       = ["any"]
+  billing_cycle    = "hourly"
+  tags = [
+    "qemu"
+  ]
+
+}
+##################################################
+## Variables that are getting outputted
+# outputing server ip address, so scripts are able
+#   to reference it
+output "v_server_ip" {
+  value = metal_device.v_packer_build_server.access_public_ipv4
+}
+
+output "q_server_ip" {
+  value = metal_device.q_packer_build_server.access_public_ipv4
+}
+
+# outputing your ip address, so scripts are able
+#   to reference it
+output "current_ip" {
+  value = jsondecode(data.http.current_ip.body).ip
+}
+##################################################
+
+terraform {
+  required_providers {
+    http = {
+      source = "hashicorp/http"
+    }
+    metal = {
+      source = "equinix/metal"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/ci/scripts/packer_build-wrapper.sh
+++ b/ci/scripts/packer_build-wrapper.sh
@@ -21,6 +21,12 @@ function packer_build() {
     vmware-iso)
       packer_build_cmd+=('-only=vmware-iso')
       ;;
+    qemu)
+      packer_build_cmd+=('-only=qemu')
+      ;;
+    *)
+      # just a stop gap to prevent automated tasks from happening.
+      read -rp 'You are about to try and build all the providers at once...are you sure[N/y]' -n 1
   esac
 
 }

--- a/ci/scripts/packer_build-wrapper.sh
+++ b/ci/scripts/packer_build-wrapper.sh
@@ -27,6 +27,7 @@ function packer_build() {
     *)
       # just a stop gap to prevent automated tasks from happening.
       read -rp 'You are about to try and build all the providers at once...are you sure[N/y]' -n 1
+      ;;
   esac
 
 }
@@ -52,6 +53,6 @@ main() {
 }
 
 # https://blog.elreydetoda.site/cool-shell-tricks/#bashscriptingbashsmain
-if [[ "${0}" = "${BASH_SOURCE[0]}" ]]; then
+if [[ "${0}" == "${BASH_SOURCE[0]}" ]]; then
   main "${@}"
 fi

--- a/scripts/template_gen.py
+++ b/scripts/template_gen.py
@@ -156,10 +156,23 @@ def builder_alterations(packer_template_data: dict, new_builder_data: dict) -> d
     prop_update = {
         'iso_url': '{{ user `iso_url` }}'
     }
+    # reminded me to do this: https://gitlab.com/kalilinux/build-scripts/kali-vagrant/-/merge_requests/5
+    # additions to bento project from here: https://github.com/lavabit/robox/blob/5e9838567fc9b396ac43fc947019c7593c5c0010/generic-libvirt.json#L3437-L3442
+    qemu_update = {
+        "disk_interface": "virtio-scsi",
+        "disk_compression": True,
+        "disk_discard": "unmap",
+        "disk_detect_zeroes": "unmap",
+        "disk_cache": "unsafe",
+        "disk_image": False
+    }
 
     for builder_dict in packer_builder_list:
         logging('updated property: {} in: {}'.format(prop_update, builder_dict['type']))
         builder_dict.update(prop_update)
+        # adding libvirt/qemu specific properties
+        if builder_dict['type'] == 'qemu':
+            builder_dict.update(qemu_update)
 
     # logging(packer_builder_list)
 
@@ -385,8 +398,12 @@ def main():
 
     ## builders section of variables
     supported_builder_list = [
-        'virtualbox-iso', 'vmware-iso',
-        'aws-ebs'
+        'virtualbox-iso',
+        'vmware-iso',
+        'aws-ebs',
+        'qemu',
+        # don't have a way to test this...
+        # 'parallels-iso'
     ]
     ## provisioner section of variables
     scripts_removal_list = [

--- a/scripts/template_gen.py
+++ b/scripts/template_gen.py
@@ -7,155 +7,158 @@ from inspect import getframeinfo, currentframe
 from pprint import pprint
 from typing import NoReturn
 from copy import deepcopy
+
 # from packerlicious import Template as packer_template
 from packerlicious import provisioner as packer_provisioner
 from packerlicious import builder as packer_builder
 from packerlicious import post_processor as packer_post_processor
-from bullet import Bullet, Input #, YesNo
+from bullet import Bullet, Input  # , YesNo
 
 # TODO: add more + better logging, w/cli arg optional
 
 # start each section with a pre-defined message and it's name
 def section_meta(current_status: str, current_func: str) -> NoReturn:
-    '''
+    """
     this is a meta function for logging information, to help you understand
     where you are in the script if it exits early or anything else like that
-    '''
+    """
     # adding extra spacing
-    print('')
+    print("")
 
     # using logging function to print
-    logging('{} {} function'.format(current_status, current_func))
+    logging("{} {} function".format(current_status, current_func))
 
     # adding extra spacing
-    print('')
+    print("")
+
 
 # logging func
 def logging(log_str: str) -> NoReturn:
-    '''
+    """
     this is to help print things out nicely (since most of data is json)
-    '''
+    """
     pprint(log_str)
+
 
 # getting pre-existing packer template from bento project
 def get_packer_template(packer_template_path: pathlib) -> json:
-    '''
+    """
     retrienve on disk a packer template file and convert it to a dict,
     also modify it by replacing all "template_dir" with packer user variables
-    '''
+    """
 
     # replacing all instances of template_dir with a user var
     #   of bento_debian_path, because that is the location it
     #   is expecting for relative file traversal
     json_string = packer_template_path.read_text().replace(
-        'template_dir', 'user `bento_debian_dir`'
-        )
+        "template_dir", "user `bento_debian_dir`"
+    )
     return json.loads(json_string)
 
+
 def variable_alterations(packer_template_data: dict, new_vars: dict) -> dict:
-    '''
+    """
     alter the variables section of the passed in packer template
-    '''
-    section_meta('starting', getframeinfo(currentframe()).function)
+    """
+    section_meta("starting", getframeinfo(currentframe()).function)
 
     # only selecting the vars section from the template
-    variables_section = packer_template_data['variables']
-
+    variables_section = packer_template_data["variables"]
 
     # list of items to remove from the template
     remove_list = [
-        'build_timestamp',
-        'git_revision',
-        'guest_additions_url',
-        'iso_name',
-        'mirror',
-        'mirror_directory',
-        'name',
-        'template',
-        'version'
-        ]
+        "build_timestamp",
+        "git_revision",
+        "guest_additions_url",
+        "iso_name",
+        "mirror",
+        "mirror_directory",
+        "name",
+        "template",
+        "version",
+    ]
 
-        # removing all items in list above
+    # removing all items in list above
     for var in remove_list:
-        logging('removed: {}'.format(var))
+        logging("removed: {}".format(var))
         del variables_section[var]
 
     # either adding or updating values in template
     sub_dict = {
-        'bento_debian_dir': str(new_vars['bento_debian_dir']),
-        'box_basename': str(new_vars['build_vm_base_output_name']),
-        'build_directory': str(new_vars['build_vm_output_dir']),
-        'build_script_dir': str(new_vars['packer_script_dir']),
-        'cpus': new_vars['build_cpus'],
-        'headless': '',
-        'http_directory': str(new_vars['http_dir']),
-        'iso_checksum': '',
-        'iso_url': '',
-        'memory': new_vars['build_memory'],
-        'preseed_path': str(new_vars['preseed_file']),
-        'template': 'packerAutoKali',
-        'vagrant_cloud_token': '',
-        'vagrantfile': str(new_vars['vagrant_template_file']),
-        'vm_version': '',
-        'vm_name': ''
+        "bento_debian_dir": str(new_vars["bento_debian_dir"]),
+        "box_basename": str(new_vars["build_vm_base_output_name"]),
+        "build_directory": str(new_vars["build_vm_output_dir"]),
+        "build_script_dir": str(new_vars["packer_script_dir"]),
+        "cpus": new_vars["build_cpus"],
+        "headless": "",
+        "http_directory": str(new_vars["http_dir"]),
+        "iso_checksum": "",
+        "iso_url": "",
+        "memory": new_vars["build_memory"],
+        "preseed_path": str(new_vars["preseed_file"]),
+        "template": "packerAutoKali",
+        "vagrant_cloud_token": "",
+        "vagrantfile": str(new_vars["vagrant_template_file"]),
+        "vm_version": "",
+        "vm_name": "",
     }
 
-    logging('updating properties for variables, section')
+    logging("updating properties for variables, section")
     variables_section.update(sub_dict)
 
     # logging(variables_section)
-    section_meta('exiting', getframeinfo(currentframe()).function)
+    section_meta("exiting", getframeinfo(currentframe()).function)
     return packer_template_data
+
 
 def sensitive_variables(packer_template_data: dict, sensitive_vars: list) -> dict:
-    '''
+    """
     declare the sensative variables section to help with security
-    '''
-    section_meta('starting', getframeinfo(currentframe()).function)
+    """
+    section_meta("starting", getframeinfo(currentframe()).function)
 
     logging(
-        'adding variables to sensative vars secions: {}'.format(
-            ', '.join(sensitive_vars)
-            )
+        "adding variables to sensative vars secions: {}".format(
+            ", ".join(sensitive_vars)
+        )
     )
-    packer_template_data['sensitive-variables'] = sensitive_vars
+    packer_template_data["sensitive-variables"] = sensitive_vars
 
-    section_meta('exiting', getframeinfo(currentframe()).function)
+    section_meta("exiting", getframeinfo(currentframe()).function)
 
     return packer_template_data
 
-def builder_alterations(packer_template_data: dict, new_builder_data: dict) -> dict:
-    '''
-    modify the builders section of the passed in packer data
-    '''
-    # TODO: add format: 'ova' to vbox builder
-    section_meta('starting', getframeinfo(currentframe()).function)
 
-    packer_builder_list = packer_template_data['builders']
+def builder_alterations(packer_template_data: dict, new_builder_data: dict) -> dict:
+    """
+    modify the builders section of the passed in packer data
+    """
+    # TODO: add format: 'ova' to vbox builder
+    section_meta("starting", getframeinfo(currentframe()).function)
+
+    packer_builder_list = packer_template_data["builders"]
 
     removing_builders_list = []
 
     for builder in packer_builder_list:
-        if builder['type'] not in new_builder_data['supported_builder_list']:
+        if builder["type"] not in new_builder_data["supported_builder_list"]:
             removing_builders_list.append(builder)
 
     for removed_builder in removing_builders_list:
-        logging('removing: {}'.format(removed_builder['type']))
+        logging("removing: {}".format(removed_builder["type"]))
         packer_builder_list.remove(removed_builder)
 
     # defining what properties have to be removed from builder
-    prop_removal = [ 'guest_additions_url' ]
+    prop_removal = ["guest_additions_url"]
 
     # removing properties and logging
     for prop_rm in prop_removal:
         for builder_dict in packer_builder_list:
             if prop_rm in builder_dict:
-                logging('removed: {} from: {}'.format(prop_rm, builder_dict['type']))
+                logging("removed: {} from: {}".format(prop_rm, builder_dict["type"]))
                 del builder_dict[prop_rm]
 
-    prop_update = {
-        'iso_url': '{{ user `iso_url` }}'
-    }
+    prop_update = {"iso_url": "{{ user `iso_url` }}"}
     # pylint: disable=line-too-long
     # reminded me to do this: https://gitlab.com/kalilinux/build-scripts/kali-vagrant/-/merge_requests/5
     # pylint: disable=line-too-long
@@ -166,209 +169,213 @@ def builder_alterations(packer_template_data: dict, new_builder_data: dict) -> d
         "disk_discard": "unmap",
         "disk_detect_zeroes": "unmap",
         "disk_cache": "unsafe",
-        "disk_image": False
+        "disk_image": False,
     }
 
     for builder_dict in packer_builder_list:
-        logging('updated property: {} in: {}'.format(prop_update, builder_dict['type']))
+        logging("updated property: {} in: {}".format(prop_update, builder_dict["type"]))
         builder_dict.update(prop_update)
         # adding libvirt/qemu specific properties
-        if builder_dict['type'] == 'qemu':
+        if builder_dict["type"] == "qemu":
             builder_dict.update(qemu_update)
 
     # logging(packer_builder_list)
 
-    section_meta('exiting', getframeinfo(currentframe()).function)
+    section_meta("exiting", getframeinfo(currentframe()).function)
 
     return packer_template_data
 
-def provisioner_alterations(packer_template_data: dict, new_prov_data: dict) -> dict:
-    '''
-    modify the provisioners section of the passed in packer data
-    '''
-    section_meta('starting', getframeinfo(currentframe()).function)
 
-    packer_prov_list = packer_template_data['provisioners']
+def provisioner_alterations(packer_template_data: dict, new_prov_data: dict) -> dict:
+    """
+    modify the provisioners section of the passed in packer data
+    """
+    section_meta("starting", getframeinfo(currentframe()).function)
+
+    packer_prov_list = packer_template_data["provisioners"]
     bento_prov = packer_prov_list[0]
     # creating deepcopy of env to use later, so we can alter it and it not
     #   mess up the original:
     #   https://stackoverflow.com/questions/2612802/how-to-clone-or-copy-a-list
 
-    bento_env_vars = bento_prov['environment_vars']
-    bash_exec_cmd = bento_prov['execute_command'].replace(' sh ', ' bash ')
+    bento_env_vars = bento_prov["environment_vars"]
+    bash_exec_cmd = bento_prov["execute_command"].replace(" sh ", " bash ")
     bento_copy_prov = deepcopy(bento_prov)
 
     cleanup_scripts = []
 
     # minimize.sh
-    cleanup_scripts.append(bento_prov['scripts'].pop())
+    cleanup_scripts.append(bento_prov["scripts"].pop())
     # cleanup.sh
-    cleanup_scripts.append(bento_prov['scripts'].pop())
+    cleanup_scripts.append(bento_prov["scripts"].pop())
 
     personal_script_dict = {
-        'environment_vars': bento_env_vars,
-        'execute_command': bash_exec_cmd,
-        'expect_disconnect': 'true',
-        'scripts': new_prov_data['scripts_custom_list']
+        "environment_vars": bento_env_vars,
+        "execute_command": bash_exec_cmd,
+        "expect_disconnect": "true",
+        "scripts": new_prov_data["scripts_custom_list"],
     }
 
     packerlicious_prov = packer_provisioner.Shell().from_dict(
-        title='CustomSystemScripts', d=personal_script_dict
-        )
+        title="CustomSystemScripts", d=personal_script_dict
+    )
     # adding my custom scripts
     packer_prov_list.insert(0, packerlicious_prov.to_dict())
     # packer_prov_list.append(packerlicious_prov.to_dict())
 
     ## SHELL: move last 2 scripts (cleanup) to bottom
     # clearing scripts section of all previous scripts
-    bento_copy_prov['scripts'].clear()
+    bento_copy_prov["scripts"].clear()
 
     for script in reversed(cleanup_scripts):
-        bento_copy_prov['scripts'].append(script)
+        bento_copy_prov["scripts"].append(script)
 
     # removing for packerlicious usage
-    del bento_copy_prov['type']
+    del bento_copy_prov["type"]
     # altering the the path for the cleanup.sh, so it
     # doesn't try to uninstall X11 packages
-    bento_copy_prov['scripts'][0] = '{}/cleanup.sh'.format(new_prov_data['prov_packer_dir'])
+    bento_copy_prov["scripts"][0] = "{}/cleanup.sh".format(
+        new_prov_data["prov_packer_dir"]
+    )
 
     packerlicious_prov = packer_provisioner.Shell().from_dict(
-        title='CleanupBentoScripts', d=bento_copy_prov
-        )
+        title="CleanupBentoScripts", d=bento_copy_prov
+    )
 
     packer_prov_list.append(packerlicious_prov.to_dict())
 
     # print(json.dumps(packer_prov_list, indent=2))
-    section_meta('exiting', getframeinfo(currentframe()).function)
+    section_meta("exiting", getframeinfo(currentframe()).function)
     return packer_template_data
 
+
 def post_processor_alterations(packer_template_data: dict, new_post_data: dict) -> dict:
-    '''
+    """
     modify the post-processors section of the passed in packer data
-    '''
-    section_meta('starting', getframeinfo(currentframe()).function)
-    post_processor_list = packer_template_data['post-processors']
+    """
+    section_meta("starting", getframeinfo(currentframe()).function)
+    post_processor_list = packer_template_data["post-processors"]
 
     # updating vagrant processor
     post_processor_list[0].update(
         {
-            'compression_level': 9 ,
-            'vagrantfile_template': '{{ user `vagrantfile` }}',
+            "compression_level": 9,
+            "vagrantfile_template": "{{ user `vagrantfile` }}",
             # needed for this: https://www.packer.io/docs/post-processors/amazon-import
-            'keep_input_artifact': True
+            "keep_input_artifact": True,
         }
     )
 
     vagrant_cloud_post_processor = packer_post_processor.VagrantCloud().from_dict(
-        title='VagrantCloudPP', d=new_post_data['vagrant-cloud']
-        )
+        title="VagrantCloudPP", d=new_post_data["vagrant-cloud"]
+    )
 
-    box_output_path = pathlib.Path(post_processor_list[0]['output'])
+    box_output_path = pathlib.Path(post_processor_list[0]["output"])
 
-    vagrant_cloud_artiface_dict = {
-        'files': [
-            str(box_output_path)
-        ]
-    }
+    vagrant_cloud_artiface_dict = {"files": [str(box_output_path)]}
 
     vagrant_cloud_artiface_post_processor = packer_post_processor.Artifice().from_dict(
-        title='VagrantCloud', d=vagrant_cloud_artiface_dict
-        )
+        title="VagrantCloud", d=vagrant_cloud_artiface_dict
+    )
 
     post_processor_list.append(
         [
             vagrant_cloud_artiface_post_processor.to_dict(),
-            vagrant_cloud_post_processor.to_dict()
+            vagrant_cloud_post_processor.to_dict(),
         ]
     )
 
     # print(json.dumps(post_processor_list, indent=2))
-    section_meta('exiting', getframeinfo(currentframe()).function)
+    section_meta("exiting", getframeinfo(currentframe()).function)
     return packer_template_data
 
-def write_packer_template(packer_template_path: pathlib, packer_template_data: dict) -> NoReturn:
-    '''
+
+def write_packer_template(
+    packer_template_path: pathlib, packer_template_data: dict
+) -> NoReturn:
+    """
     write the post processors section to disk
-    '''
-    section_meta('starting', getframeinfo(currentframe()).function)
+    """
+    section_meta("starting", getframeinfo(currentframe()).function)
 
     # logging(packer_template_data)
-    packer_template_path.write_text(json.dumps(packer_template_data, indent=2), encoding='utf-8')
+    packer_template_path.write_text(
+        json.dumps(packer_template_data, indent=2), encoding="utf-8"
+    )
 
-    section_meta('exiting', getframeinfo(currentframe()).function)
+    section_meta("exiting", getframeinfo(currentframe()).function)
+
 
 def get_builder_aws_ebs() -> packer_builder:
-    '''
+    """
     build the aws builder section
-    '''
-    section_meta('starting', getframeinfo(currentframe()).function)
+    """
+    section_meta("starting", getframeinfo(currentframe()).function)
 
     variable_dictionary = {
-        'source_ami' : "{{ user `kali_aws_ami` }}",
-        'region' : "{{ user `aws_region` }}",
-        'ssh_username' : "kali",
-        'instance_type' : "t2.medium",
-        'ami_name' : "Kali Linux (Standard)",
-        "ami_users": [ "" ],
+        "source_ami": "{{ user `kali_aws_ami` }}",
+        "region": "{{ user `aws_region` }}",
+        "ssh_username": "kali",
+        "instance_type": "t2.medium",
+        "ami_name": "Kali Linux (Standard)",
+        "ami_users": [""],
         "force_deregister": "true",
-        "force_delete_snapshot": "true"
+        "force_delete_snapshot": "true",
     }
 
     auth_prompt = Bullet(
-        prompt = 'Choose from the items below: ',
-        choices = [
-            'AWS Profile',
-            'AWS Access Key'
-        ]
+        prompt="Choose from the items below: ",
+        choices=["AWS Profile", "AWS Access Key"],
     )
 
     auth_type = auth_prompt.launch()
 
-    if auth_type == 'AWS Profile':
+    if auth_type == "AWS Profile":
         profile_prompt = Input(
-            prompt = 'Please input the profile you would like to use: '
+            prompt="Please input the profile you would like to use: "
         )
         current_profile = profile_prompt.launch()
 
-        variable_dictionary.update(
-            {
-                'profile' : "{}".format(current_profile)
-            }
-        )
+        variable_dictionary.update({"profile": "{}".format(current_profile)})
 
-    elif auth_type == 'AWS Access Key':
+    elif auth_type == "AWS Access Key":
 
         variable_dictionary.update(
             {
-                'access_key' : "{{ user `aws_access_key` }}",
-                'secret_key' : "{{ user `aws_secret_key` }}"
+                "access_key": "{{ user `aws_access_key` }}",
+                "secret_key": "{{ user `aws_secret_key` }}",
             }
         )
 
     else:
-        print('unknown auth type: {}'.format(auth_type))
+        print("unknown auth type: {}".format(auth_type))
 
-    aws_ebs_builder = packer_builder.AmazonEbs().from_dict('AmazonEBS', d=variable_dictionary)
+    aws_ebs_builder = packer_builder.AmazonEbs().from_dict(
+        "AmazonEBS", d=variable_dictionary
+    )
     # TODO: fixin base package to accept string
     aws_ebs_builder_dict = aws_ebs_builder.to_dict()
-    aws_ebs_builder_dict['ami_users'] = "{{user `ami_users`}}"
-    section_meta('exiting', getframeinfo(currentframe()).function)
+    aws_ebs_builder_dict["ami_users"] = "{{user `ami_users`}}"
+    section_meta("exiting", getframeinfo(currentframe()).function)
     return aws_ebs_builder_dict
+
 
 # TODO: adding aspirations
 # def add_builder_hyperv():
 
+
 def append_builder(packer_template_data: dict, new_builder: dict) -> dict:
-    '''
+    """
     add given builder to packer template blob
-    '''
-    section_meta('starting', getframeinfo(currentframe()).function)
+    """
+    section_meta("starting", getframeinfo(currentframe()).function)
 
-    packer_template_data['builders'].append(new_builder)
+    packer_template_data["builders"].append(new_builder)
 
-    section_meta('exiting', getframeinfo(currentframe()).function)
+    section_meta("exiting", getframeinfo(currentframe()).function)
 
     return packer_template_data
+
 
 # pylint: disable=C0116
 def main():
@@ -385,49 +392,50 @@ def main():
     project_root = script_dir.parent
 
     # packer provisioning scripts dir
-    prov_packer_dir = project_root / 'prov_packer'
+    prov_packer_dir = project_root / "prov_packer"
 
-    new_packer_template = project_root / 'kali-template.json'
+    new_packer_template = project_root / "kali-template.json"
 
-    http_preseed_dir = project_root / 'install' / 'http'
-    http_preseed_file = 'kali-linux-rolling-preseed.cfg'
-    vagrant_template_file = project_root / 'install' / 'vagrantfile-kali_linux.template'
+    http_preseed_dir = project_root / "install" / "http"
+    http_preseed_file = "kali-linux-rolling-preseed.cfg"
+    vagrant_template_file = project_root / "install" / "vagrantfile-kali_linux.template"
 
-    build_cpus = '2'
-    build_memory = '4096'
+    build_cpus = "2"
+    build_memory = "4096"
     build_vm_output_dir = project_root
-    build_vm_base_output_name = 'red-automated_kali'
+    build_vm_base_output_name = "red-automated_kali"
 
     ## builders section of variables
     supported_builder_list = [
-        'virtualbox-iso',
-        'vmware-iso',
-        'aws-ebs',
-        'qemu',
+        "virtualbox-iso",
+        "vmware-iso",
+        "aws-ebs",
+        "qemu",
         # don't have a way to test this...
         # 'parallels-iso'
     ]
     ## provisioner section of variables
-    scripts_removal_list = [
-        'virtualbox.sh'
-    ]
+    scripts_removal_list = ["virtualbox.sh"]
     prov_packer_dir_str = str(prov_packer_dir)
     scripts_custom_list = [
-        '{}/full-update.sh'.format(prov_packer_dir_str),
-        '{}/vagrant.sh'.format(prov_packer_dir_str),
-        '{}/customization.sh'.format(prov_packer_dir_str),
-        '{}/docker.sh'.format(prov_packer_dir_str),
-        '{}/networking.sh'.format(prov_packer_dir_str),
-        '{}/virtualbox.sh'.format(prov_packer_dir_str)
+        "{}/full-update.sh".format(prov_packer_dir_str),
+        "{}/vagrant.sh".format(prov_packer_dir_str),
+        "{}/customization.sh".format(prov_packer_dir_str),
+        "{}/docker.sh".format(prov_packer_dir_str),
+        "{}/networking.sh".format(prov_packer_dir_str),
+        "{}/virtualbox.sh".format(prov_packer_dir_str),
     ]
 
-    parser = ArgumentParser(description='''
+    parser = ArgumentParser(
+        description="""
     This script is used to generate the packer file template
     for doing an auotmated kali installation
-    ''')
+    """
+    )
 
-    parser.add_argument( '-a', '--aws', action='store_true',
-        help='also build the aws-ebs builder')
+    parser.add_argument(
+        "-a", "--aws", action="store_true", help="also build the aws-ebs builder"
+    )
 
     # parser.add_argument(
     #     '-b','--builders', nargs='*', default=[ 'all' ],
@@ -441,15 +449,15 @@ def main():
     ## Bento
 
     # bento dir
-    bento_base_dir = prov_packer_dir / 'bento'
+    bento_base_dir = prov_packer_dir / "bento"
 
     # bento packer_templates dir
-    bento_packer_template = bento_base_dir / 'packer_templates'
+    bento_packer_template = bento_base_dir / "packer_templates"
 
     # necessary folder in packer templates dir
-    bento_debian_dir = bento_packer_template / 'debian'
+    bento_debian_dir = bento_packer_template / "debian"
 
-    bento_current_packer_template = bento_debian_dir / 'debian-10.5-amd64.json'
+    bento_current_packer_template = bento_debian_dir / "debian-10.5-amd64.json"
 
     ###
 
@@ -459,16 +467,16 @@ def main():
     ### variable alterations section
     # variables to update
     new_variables = {
-        'bento_debian_dir': bento_debian_dir,
-        'packer_script_dir': prov_packer_dir,
-        'http_dir': http_preseed_dir,
-        'preseed_file': http_preseed_file,
-        'project_root': project_root,
-        'build_cpus': build_cpus,
-        'build_memory': build_memory,
-        'vagrant_template_file': vagrant_template_file,
-        'build_vm_output_dir': build_vm_output_dir,
-        'build_vm_base_output_name': build_vm_base_output_name
+        "bento_debian_dir": bento_debian_dir,
+        "packer_script_dir": prov_packer_dir,
+        "http_dir": http_preseed_dir,
+        "preseed_file": http_preseed_file,
+        "project_root": project_root,
+        "build_cpus": build_cpus,
+        "build_memory": build_memory,
+        "vagrant_template_file": vagrant_template_file,
+        "build_vm_output_dir": build_vm_output_dir,
+        "build_vm_base_output_name": build_vm_base_output_name,
     }
 
     # updating variables
@@ -476,9 +484,7 @@ def main():
 
     ### sensitive variables section
     # list of sensitive variables
-    sensitive_var_list = [
-        'vagrant_cloud_token'
-    ]
+    sensitive_var_list = ["vagrant_cloud_token"]
 
     # adding list of sensative variables
     updated_packer_data = sensitive_variables(updated_packer_data, sensitive_var_list)
@@ -486,9 +492,7 @@ def main():
     # TODO: fix logic error to where other builders are looped over here
     #   when 'all' is the array
     ### builder alterations section
-    builder_info_dict = {
-        'supported_builder_list': supported_builder_list
-    }
+    builder_info_dict = {"supported_builder_list": supported_builder_list}
     updated_packer_data = builder_alterations(updated_packer_data, builder_info_dict)
 
     if args.aws:
@@ -496,32 +500,34 @@ def main():
 
     ### provisioner alterations section
     prov_info_dict = {
-        'prov_packer_dir': prov_packer_dir,
-        'scripts_removal_list': scripts_removal_list,
-        'scripts_custom_list': scripts_custom_list
+        "prov_packer_dir": prov_packer_dir,
+        "scripts_removal_list": scripts_removal_list,
+        "scripts_custom_list": scripts_custom_list,
     }
     updated_packer_data = provisioner_alterations(updated_packer_data, prov_info_dict)
 
     ### post provisioner alterations section
     post_processor_dict = {
         # configured in the post_processor_alterations func
-        'vagrant-cloud-artiface': {
+        "vagrant-cloud-artiface": {},
+        "vagrant-cloud": {
+            "box_tag": "{{user `vm_name`}}",
+            "access_token": "{{user `vagrant_cloud_token`}}",
+            "version": "{{user `vm_version`}}",
         },
-        'vagrant-cloud': {
-            'box_tag': '{{user `vm_name`}}',
-            'access_token': '{{user `vagrant_cloud_token`}}',
-            'version': '{{user `vm_version`}}',
-            }
     }
     if not args.aws:
-        updated_packer_data = post_processor_alterations(updated_packer_data, post_processor_dict)
+        updated_packer_data = post_processor_alterations(
+            updated_packer_data, post_processor_dict
+        )
     elif args.aws:
-        del updated_packer_data['post-processors']
+        del updated_packer_data["post-processors"]
 
     # logging(updated_packer_data)
 
     # writing out to file
     write_packer_template(new_packer_template, updated_packer_data)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/template_gen.py
+++ b/scripts/template_gen.py
@@ -156,7 +156,9 @@ def builder_alterations(packer_template_data: dict, new_builder_data: dict) -> d
     prop_update = {
         'iso_url': '{{ user `iso_url` }}'
     }
+    # pylint: disable=line-too-long
     # reminded me to do this: https://gitlab.com/kalilinux/build-scripts/kali-vagrant/-/merge_requests/5
+    # pylint: disable=line-too-long
     # additions to bento project from here: https://github.com/lavabit/robox/blob/5e9838567fc9b396ac43fc947019c7593c5c0010/generic-libvirt.json#L3437-L3442
     qemu_update = {
         "disk_interface": "virtio-scsi",

--- a/scripts/terraform-helper.sh
+++ b/scripts/terraform-helper.sh
@@ -14,15 +14,19 @@ function terraform_stuff() {
 
   case "${terraform_action}" in
     init)
-      extra_args=("${terraform_folder}/")
+      pre_args=("-chdir=${terraform_folder}/")
+      extra_args=()
       ;;
     plan)
-      extra_args=("-out" "${plan_file}" "${terraform_folder}/")
+      pre_args=("-chdir=${terraform_folder}/")
+      extra_args=("-out" "${plan_file}")
       ;;
     apply)
       if [[ -n "${TF_VAR_tc_auth_token:-}" ]]; then
-        extra_args=("-auto-approve" "${terraform_folder}/")
+        pre_args=("-chdir=${terraform_folder}/")
+        extra_args=("-auto-approve")
       else
+        pre_args=()
         extra_args=("-state" "${state_file}")
       fi
       ;;
@@ -31,6 +35,7 @@ function terraform_stuff() {
       # wbm: https://web.archive.org/web/20161121105825/http://stackoverflow.com/questions/19482123/extract-part-of-a-string-using-bash-cut-split#answer-19482947
       terraform_action="${terraform_action%-*}"
       extra_args=("-state" "${state_file}" "${plan_file}")
+      pre_args=()
       ;;
     output)
       if [[ -n "${TF_VAR_tc_auth_token:-}" ]]; then
@@ -45,19 +50,22 @@ function terraform_stuff() {
         extra_args+=("${2}")
       fi
       set -u
+      pre_args=()
       terraform_provider='none'
       ;;
     destroy)
       if [[ -n "${TF_VAR_tc_auth_token:-}" ]]; then
-        extra_args=("-auto-approve" "${terraform_folder}/")
+        extra_args=("-auto-approve")
       else
-        extra_args=("-auto-approve" "-state" "${state_file}" "${terraform_folder}/")
+        extra_args=("-auto-approve" "-state" "${state_file}")
       fi
+      pre_args=("-chdir=${terraform_folder}/")
       ;;
     *)
       IFS=" " read -r -a extra_args <<< "${@:2}"
       if [[ -z "${extra_args[*]}" ]]; then
         extra_args=()
+        pre_args=()
       fi
       ;;
 
@@ -93,7 +101,7 @@ function terraform_stuff() {
       -v "$(pwd)/.terraform.d":/root/.terraform.d/ \
       -v "$(pwd)/.terraform":/.terraform/ \
       -v "$(pwd)":"${terraform_folder}/" \
-      hashicorp/terraform:light "${terraform_action}" "${extra_args[@]}"
+      hashicorp/terraform:light "${pre_args[@]}" "${terraform_action}" "${extra_args[@]}"
   else
 
     # shellcheck disable=SC2140
@@ -103,7 +111,7 @@ function terraform_stuff() {
       "${provider_array[@]}" \
       -v "$(pwd)/.terraform":/.terraform/ \
       -v "$(pwd)":"${terraform_folder}/" \
-      hashicorp/terraform:light "${terraform_action}" "${extra_args[@]}"
+      hashicorp/terraform:light "${pre_args[@]}" "${terraform_action}" "${extra_args[@]}"
   fi
 
 }
@@ -154,6 +162,6 @@ function main() {
 }
 
 # https://blog.elreydetoda.site/cool-shell-tricks/#bashscriptingbashsmain
-if [[ "${0}" = "${BASH_SOURCE[0]}" ]]; then
+if [[ "${0}" == "${BASH_SOURCE[0]}" ]]; then
   main "${@}"
 fi


### PR DESCRIPTION
wanted to add this support for a while, but seeing [this PR](https://gitlab.com/kalilinux/build-scripts/kali-vagrant/-/merge_requests/5) showed me that it was probably pretty trivial. Overall that was true, and [here](https://app.circleci.com/pipelines/github/elreydetoda/packer-kali_linux/406/workflows/eaa031dc-ced7-4904-bab1-ddf0c2d1d9b8) was my first CircleCI build for my [dev box](https://app.vagrantup.com/elrey741/boxes/kali-linux_amd64-dev) with [0.0.12](https://app.vagrantup.com/elrey741/boxes/kali-linux_amd64-dev/versions/0.0.12) being the first dev release w/libvirt support.

[This](https://3067-119017409-gh.circle-artifacts.com/0/tmp/artifacts/kali-template.json) ( which I generated from my [template generation script](https://github.com/elreydetoda/packer-kali_linux/blob/5c0228a8ded976c7313dad08a5a916aad1086497/scripts/template_gen.py) ) was my packer file used to generate the box, and I also uploaded it below as an artifact :grin:  ( appended `.txt` so GH would accept it :upside_down_face: )


[kali-template.json.txt](https://github.com/elreydetoda/packer-kali_linux/files/6411960/kali-template.json.txt)
